### PR TITLE
Split pipeline instance wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,45 @@ $ origo datasets cp /tmp/test.txt ds:my-dataset
 The `cp` command operates with a `ds` prefix to specify
 
 If an error occurs: ensure that the latest version have a edition
+
+## Using a pipeline
+When you can upload a file to an edition, you can attach a Pipeline to the dataset.
+The easiest way is by using the Pipeline Instance Wizard:
+`origo pipelines intances wizard` 
+
+### Wizard
+1. Input a dataset id and select a version which the pipeline should write to
+2. Select a pipeline
+3. Input a transformation json object.
+    3. A empty version of the transformation object is provided. All properties may not be required
+4. Input a schema ID or leave it blank
+5. Select whether or not the pipeline should create a new edition when completing a pipeline run.
+
+When you upload a new data file, the pipeline will automatically start. 
+
+### Manually
+The requirements is a Pipeline Instance which refers to an existing Pipeline, and an output dataset. 
+Lookup available Pipelines with `origo pipelines ls` 
+
+pipeline_instance.json
+```
+{
+    "pipelineArn": "arn:some:aws:id:to:123456789101:test-pipeline",
+    "id": "my-dataset",
+    "datasetUri": "output/my-dataset/1",
+    "transformation": { "step1": "..." },
+    "useLatestEdition": false
+}
+```
+Pipeline Instance contains information about what to do in a pipeline. But a Pipeline Input is also required to indicate what will trigger the Instance.
+
+Create by `origo pipelines instances create --file pipeline_instance.json`
+
+pipeline_input.json
+```
+{
+    "datasetUri": "input/my-dataset/1",
+    "stage": "incoming",
+    "pipelineInstanceId": "my-dataset"
+}
+```

--- a/origocli/wizards.py
+++ b/origocli/wizards.py
@@ -8,6 +8,7 @@ from inquirer.errors import ValidationError
 from jsonschema import ValidationError as SchemaValidationError
 from origo.data.dataset import Dataset
 from origo.pipelines.client import PipelineApiClient
+from origo.pipelines.resources.pipeline_input import PipelineInput
 from origo.pipelines.resources.pipeline_instance import PipelineInstance
 from origocli.command import BaseCommand
 
@@ -139,6 +140,17 @@ def pipeline_instance_wizard(sdk: Dataset, dataset: dict = None, pipeline=None):
     )
     response, error = pipeline_instance.create()
 
+    if error:
+        raise SystemExit(error, error.response.text)
+
+    pipeline_input = PipelineInput(
+        sdk,
+        datasetUri=f"input/{dataset['Id']}/{version['version']}",
+        stage="incoming",
+        pipelineInstanceId=pipeline_instance.id,
+    )
+
+    response, error = pipeline_input.create()
     if error:
         raise SystemExit(error, error.response.text)
 

--- a/origocli/wizards.py
+++ b/origocli/wizards.py
@@ -1,0 +1,125 @@
+import json
+from json import JSONDecodeError
+
+import inquirer
+import jsonschema
+from fuzzywuzzy import process
+from inquirer.errors import ValidationError
+from jsonschema import ValidationError as SchemaValidationError
+from origo.data.dataset import Dataset
+from origo.pipelines.client import PipelineApiClient
+from origo.pipelines.resources.pipeline_instance import PipelineInstance
+
+from origocli.command import BaseCommand
+
+
+class MissingVersionExit(SystemExit):
+    def __init__(self):
+        super().__init__("missing Version in dataset metadata")
+
+
+class InvalidTransformation(Exception):
+    def __init__(self, errors):
+        super().__init__("invalid transformation schema: ", errors)
+
+
+def select_dataset(sdk: Dataset, datasets=None):
+    if datasets is None:
+        datasets = sdk.get_datasets()
+    dataset_ids = [dataset["Id"] for dataset in datasets]
+
+    def validate_dataset(answers, current):
+        if current not in dataset_ids:
+            possible_matches = process.extractBests(current, dataset_ids, limit=5)
+            possible_matches = [match[0] for match in possible_matches]
+            reason = f"Dataset does not exist. Similar datasets ids include: {' '.join(possible_matches)}"
+            raise ValidationError(
+                    False,
+                    reason=reason,
+            )
+        return True
+
+    q = [inquirer.Text(
+            "dataset-id",
+            message="What is the output dataset ID ?",
+            validate=validate_dataset,
+    )]
+    answers = inquirer.prompt(q)
+    return next(dataset for dataset in datasets if answers["dataset-id"] == dataset["Id"])
+
+
+def select_pipeline(sdk: PipelineApiClient, pipelines=None):
+    if pipelines is None:
+        pipelines = sdk.get_pipelines()
+    arns = [pipeline["arn"] for pipeline in pipelines]
+
+    q = [inquirer.List("pipeline", message="Select a pipeline", choices=arns)]
+    answers = inquirer.prompt(q)
+    return next(pipeline for pipeline in pipelines if answers["pipeline"] == pipeline["arn"])
+
+
+def select_version(sdk: Dataset, dataset_id):
+    versions = sdk.get_versions(dataset_id)
+    if len(versions) < 1:
+        raise MissingVersionExit
+    all_versions = [version["version"] for version in versions]
+
+    q = [inquirer.List("version", message="Select a version", choices=all_versions)]
+    answers = inquirer.prompt(q)
+    return next(version for version in versions if answers["version"] == version["version"])
+
+
+def pipeline_instance_wizard(sdk: Dataset, dataset: dict = None, pipeline=None):
+    if dataset is None:
+        dataset = select_dataset(sdk)
+    if pipeline is None:
+        pipeline = select_pipeline(PipelineApiClient(config=sdk.config, auth=sdk.auth))
+
+    version = select_version(sdk, dataset["Id"])
+    questions = [
+        inquirer.Text(
+                "schema-id",
+                message="Use a schema? Please enter schema-id (empty for no schema)",
+                default="",
+        ),
+        inquirer.List(
+                "create-edition",
+                message="Should a new edition be created after this pipeline succeeds?",
+                choices=[True, False],
+        ),
+        inquirer.Editor("transformation", message="Provide a transformation object"),
+    ]
+
+    answers = inquirer.prompt(questions)
+
+    while True:
+        try:
+            jsonschema.validate(json.loads(answers["transformation"]),
+                                schema=json.loads(pipeline["transformation_schema"]))
+        except SchemaValidationError as e:
+            print("Input must match the transformation Schema: ")
+            BaseCommand.pretty_json(e.schema)
+            print(e.__repr__())
+            answers.update(
+                inquirer.prompt([inquirer.Editor("transformation", message="Provide a transformation object")]))
+        except JSONDecodeError:
+            print("Not valid JSON!")
+            answers.update(
+                    inquirer.prompt([inquirer.Editor("transformation", message="Provide a transformation object")]))
+        else:
+            break
+
+    pipeline_instance, error = PipelineInstance(
+            sdk,
+            id=dataset['Id'],
+            pipelineArn=pipeline["arn"],
+            datasetUri=f"output/{dataset['Id']}/{version['version']}",
+            schemaId=answers["schema-id"],
+            transformation=json.loads(answers["transformation"]),
+            useLatestEdition=not answers["create-edition"],
+    ).create()
+
+    if error:
+        raise SystemExit(error)
+
+    return pipeline_instance


### PR DESCRIPTION
Split the wizard into other usable parts. 
For instance can be tagged onto `create_dataset` + `version` or similar. 
The wizard will try to use `transformation_schema` to help creating the transformation 

Try with `origo pipelines instances wizard` 