### PR TITLE
Print out properly formatted json for dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ File: dataset.json
 {
     "title": "My dataset",
     "description": "My dataset description",
+    "theme": ["environment"],
     "keywords": ["keyword", "for-indexing"],
     "accessRights": "public",
     "confidentiality": "green",

--- a/origocli/commands/datasets.py
+++ b/origocli/commands/datasets.py
@@ -19,7 +19,7 @@ class DatasetsCommand(BaseCommand):
       origo datasets ls [--format=<format> --env=<env> --filter=<filter>] [options]
       origo datasets ls <datasetid> [<versionid> <editionid>][--format=<format> --env=<env> options]
       origo datasets cp <filepath> <datasetid> [<versionid> <editionid> --format=<format> --env=<env> options]
-      origo datasets create [--file=<file --format=<format> --env=<env> options]
+      origo datasets create [--file=<file> --format=<format> --env=<env> options]
       origo datasets create-version <datasetid> [--file=<file> --format=<format> --env=<env> options]
       origo datasets create-edition <datasetid> [<versionid>] [--file=<file> --format=<format --env=<env> options]
       origo datasets create-distribution <datasetid> [<versionid> <editionid>] [--file=<file> --format=<format --env=<env> options]

--- a/origocli/commands/datasets.py
+++ b/origocli/commands/datasets.py
@@ -9,6 +9,8 @@ from origocli.date import (
 from origo.data.dataset import Dataset
 from origo.data.upload import Upload
 
+import json
+
 
 class DatasetsCommand(BaseCommand):
     """Oslo :: Datasets
@@ -86,7 +88,7 @@ class DatasetsCommand(BaseCommand):
                 list["dataset"] = set
                 list["versions"] = versions
                 list["latest"] = latest
-                self.print("", list)
+                self.print("", json.dumps(list))
                 return
 
             out = create_output(self.opt("format"), "datasets_dataset_config.json")

--- a/tests/origocli/commands/datasets_test.py
+++ b/tests/origocli/commands/datasets_test.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+import json
 
 import pytest
 from origo.data.dataset import Dataset
@@ -90,9 +91,8 @@ class TestDatasetsLs:
     def test_dataset_format_json(self, mocker, mock_print):
         cmd = create_cmd(mocker, "ls", dataset["Id"], "--format", "json")
         cmd.handler()
-        mock_print.assert_called_once_with(
-            "", {"dataset": dataset, "versions": [version], "latest": version}
-        )
+        expected_output = {"dataset": dataset, "versions": [version], "latest": version}
+        mock_print.assert_called_once_with("", json.dumps(expected_output))
         assert cmd.sdk.get_dataset.called
         assert cmd.sdk.get_versions.called
         assert cmd.sdk.get_latest_version.called


### PR DESCRIPTION
The command currently prints out the object in Python dict format, which is not valid JSON (e.g. uses `'` instead of `"`).