### PR TITLE
Remove processing stage from example dataset JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ origo datasets ls my-dataset my-edition
 
 ## Create dataset
 File: dataset.json
-```
+```json
 {
     "title": "My dataset",
     "description": "My dataset description",
@@ -89,8 +89,7 @@ File: dataset.json
         "email": "contact.name@example.org",
         "phone": "999555111"
     },
-    "publisher": "my organization",
-    "processing_stage": "raw"
+    "publisher": "my organization"
 }
 
 ```


### PR DESCRIPTION
Using the suggested JSON data from the README when creating a dataset results in a validation error:

```
An error occured: Validation error
Cause:
	["Additional properties are not allowed ('processing_stage' was unexpected)"]
```

It seems that `processing_stage` isn't an accepted key, so remove it from the guide.