### PR TITLE
DP-784 Allow reading stdin from a tty

### DIFF
--- a/origocli/io.py
+++ b/origocli/io.py
@@ -12,11 +12,10 @@ def read_stdin_or_filepath(file):
         with open(file) as f:
             payload = json.load(f)
     else:
-        if not sys.stdin.isatty():
-            log.info("Reading data from stdin")
-            data = ""
-            for i, dataline in enumerate(sys.stdin, start=1):
-                data = f"{data}\n{dataline}"
-            payload = json.loads(data)
+        log.info("Reading data from stdin")
+        data = ""
+        for i, dataline in enumerate(sys.stdin, start=1):
+            data = f"{data}\n{dataline}"
+        payload = json.loads(data)
     # TODO: raise DataNotFoundException()
     return payload


### PR DESCRIPTION
Make commands reading from stdin more convenient by allowing them to read input from a tty as well, as is customary among standard UNIX text tools.