### PR TITLE
DP-791 Rename `event_streams` to `event-streams`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,23 +163,23 @@ version](#create-version) for the dataset. If such already exist you are good to
 
 Create:
 ```
-$ origo event_streams create <datasetid> <version>
+$ origo event-streams create <datasetid> <version>
 ```
 Note! You can not start sending event to the stream right away. You must wait until
-the stream status is ACTIVE. To poll for the stream-status you can use the following (Get) `origo event_streams ls` - command.
+the stream status is ACTIVE. To poll for the stream-status you can use the following (Get) `origo event-streams ls` - command.
 
 Get:
 ```
-$ origo event_streams ls <datasetid> <version>
+$ origo event-streams ls <datasetid> <version>
 ```
 Delete:
 ```
-$ origo event_streams delete <datasetid> <version>
+$ origo event-streams delete <datasetid> <version>
 ```
 
 ## Sending Events
 
-In order to send events you need to [create an event stream](#creating-event-streams). 
+In order to send events you need to [create an event stream](#creating-event-streams).
 If such already exist you are good to go.
 
 Sending single json-events and lists of json-events can be done as follows:

--- a/bin/cli.py
+++ b/bin/cli.py
@@ -60,7 +60,7 @@ def get_command_class(argv):
         "datasets": DatasetsCommand,
         "events": EventsCommand,
         "pipelines": Pipelines,
-        "event_streams": EventStreamCommand,
+        "event-streams": EventStreamCommand,
         "status": StatusCommand,
         "webhooks": WebhookTokensCommand,
     }

--- a/origocli/command.py
+++ b/origocli/command.py
@@ -19,7 +19,7 @@ class BaseCommand:
   origo status [options]
   origo pipelines [options]
   origo events [options]
-  origo event_streams [options]
+  origo event-streams [options]
   origo webhooks [options]
   origo -h | --help
 
@@ -28,7 +28,7 @@ Commands available:
   status
   pipelines
   events
-  event_streams
+  event-streams
   webhooks
 
 Options:{BASE_COMMAND_OPTIONS}

--- a/origocli/commands/event_streams.py
+++ b/origocli/commands/event_streams.py
@@ -8,14 +8,14 @@ class EventStreamCommand(BaseCommand):
     __doc__ = f"""Oslo :: Event streams
 
 Usage:
-  origo event_streams create <datasetid> <version> [options]
-  origo event_streams ls <datasetid> <version> [options]
-  origo event_streams delete <datasetid> <version> [options]
+  origo event-streams create <datasetid> <version> [options]
+  origo event-streams ls <datasetid> <version> [options]
+  origo event-streams delete <datasetid> <version> [options]
 
 Examples:
-  origo event_streams create some-dataset-id 1
-  origo event_streams ls test-event-stream 1 --format=json | jq ".status" -r
-  origo event_streams delete some-dataset-id 1
+  origo event-streams create some-dataset-id 1
+  origo event-streams ls test-event-stream 1 --format=json | jq ".status" -r
+  origo event-streams delete some-dataset-id 1
 
 Options:{BASE_COMMAND_OPTIONS}
     """

--- a/tests/origocli/commands/event_stream_test.py
+++ b/tests/origocli/commands/event_stream_test.py
@@ -6,7 +6,7 @@ from origo.event.event_stream_client import EventStreamClient
 
 
 def test_create(mock_event_stream_sdk, mocker):
-    set_argv("event_streams", "create", "some-dataset-id", "1")
+    set_argv("event-streams", "create", "some-dataset-id", "1")
     cmd = EventStreamCommand()
     mocker.spy(cmd.sdk, "create_event_stream")
     cmd.handler()
@@ -14,7 +14,7 @@ def test_create(mock_event_stream_sdk, mocker):
 
 
 def test_ls(mock_event_stream_sdk, mocker):
-    set_argv("event_streams", "ls", "some-dataset-id", "1")
+    set_argv("event-streams", "ls", "some-dataset-id", "1")
     cmd = EventStreamCommand()
     mocker.spy(cmd.sdk, "get_event_stream_info")
     cmd.handler()
@@ -22,7 +22,7 @@ def test_ls(mock_event_stream_sdk, mocker):
 
 
 def test_delete(mock_event_stream_sdk, mocker):
-    set_argv("event_streams", "delete", "some-dataset-id", "1")
+    set_argv("event-streams", "delete", "some-dataset-id", "1")
     cmd = EventStreamCommand()
     mocker.spy(cmd.sdk, "delete_event_stream")
     cmd.handler()


### PR DESCRIPTION
Rename the `event_streams` command to `event-streams` for consistency with the rest of the CLI, which uses dash to separate words in multi-word commands.