### PR TITLE
Turn f-strings without placeholders into normal strings

### DIFF
--- a/origocli/commands/pipelines/pipelines.py
+++ b/origocli/commands/pipelines/pipelines.py
@@ -27,7 +27,7 @@ class PipelinesLs(BasePipelinesCommand):
         out = create_output(self.opt("format"), "pipelines_config.json")
         pipelines = self.sdk.get_pipelines()
         out.add_rows(pipelines)
-        self.print(f"Available pipelines", out)
+        self.print("Available pipelines", out)
 
 
 class PipelinesCreate(BasePipelinesCommand):

--- a/origocli/commands/pipelines/schemas.py
+++ b/origocli/commands/pipelines/schemas.py
@@ -20,7 +20,7 @@ class SchemasLs(BasePipelinesCommand):
         )
         schemas = self.sdk.get_schemas()
         out.add_rows(schemas)
-        self.print(f"List of Schemas available", out)
+        self.print("List of Schemas available", out)
 
 
 class SchemasCreate(BasePipelinesCommand):

--- a/origocli/commands/status.py
+++ b/origocli/commands/status.py
@@ -65,7 +65,7 @@ Options:{BASE_COMMAND_OPTIONS}
             self.print(f"Status for: {statusid}", out)
         else:
             self.print(
-                f"No history found for status",
+                "No history found for status",
                 {"error": 1, "message": "No statuses found"},
             )
 


### PR DESCRIPTION
Turn f-strings without placeholders into normal strings to stop flake8 from complaining about: "F541 f-string is missing placeholders".