### PR TITLE
DP-1091 Remove fuzzywuzzy and python-levenshtein

### DIFF
--- a/origocli/commands/pipelines/instances.py
+++ b/origocli/commands/pipelines/instances.py
@@ -1,7 +1,6 @@
 import json
 import inquirer
 from inquirer.errors import ValidationError
-from fuzzywuzzy import process
 
 from origo.data.dataset import Dataset
 from origo.pipelines.resources.pipeline_instance import PipelineInstance
@@ -132,11 +131,8 @@ class PipelineInstanceWizard(BasePipelinesCommand):
 
         def validate_dataset(answers, current):
             if current not in datasets:
-                possible_matches = process.extractBests(current, datasets, limit=3)
-                possible_matches = [match[0] for match in possible_matches]
                 raise ValidationError(
-                    False,
-                    reason=f"Dataset does not exist. Similar datasets ids include: {possible_matches}",
+                    False, reason="Dataset does not exist.",
                 )
             return True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 docopt==0.6.2             # via origo-cli (setup.py)
 ecdsa==0.15               # via python-jose
-fuzzywuzzy==0.18.0        # via origo-cli (setup.py)
 idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via jsonschema
 inquirer==2.6.3           # via origo-cli (setup.py)
@@ -24,7 +23,6 @@ pyrsistent==0.16.0        # via jsonschema
 python-editor==1.0.4      # via inquirer
 python-jose==3.1.0        # via python-keycloak
 python-keycloak==0.20.0   # via origo-sdk-python
-python-levenshtein==0.12.0  # via origo-cli (setup.py)
 readchar==2.0.1           # via inquirer
 requests==2.23.0          # via origo-cli (setup.py), origo-sdk-python, python-keycloak
 rsa==4.0                  # via python-jose

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,6 @@ setuptools.setup(
         "requests",
         "origo-sdk-python>=0.2.2",
         "inquirer",
-        "fuzzywuzzy",
-        "python-Levenshtein",
         "pygments",
     ],
     entry_points={"console_scripts": ["origo=bin.cli:main"]},


### PR DESCRIPTION
Remove the GPL-licensed fuzzywuzzy and python-levenshtein libraries to avoid having to re-license Origo CLI.

They were only used for an experimental feature.