### PR TITLE
DP-934: Add commands for event-stream-api

### DIFF
--- a/bin/cli.py
+++ b/bin/cli.py
@@ -10,6 +10,7 @@ from origocli.command import BaseCommand
 from origocli.commands.datasets import DatasetsCommand
 from origocli.commands.event_streams import EventStreamCommand
 from origocli.commands.events import EventsCommand
+from origocli.commands.eventsng import Events
 from origocli.commands.pipelines import Pipelines
 from origocli.commands.status import StatusCommand
 from origocli.commands.webhook_tokens import WebhookTokensCommand
@@ -58,6 +59,7 @@ def main():
 def get_command_class(argv):
     commands = {
         "datasets": DatasetsCommand,
+        "eventsng": Events,
         "events": EventsCommand,
         "pipelines": Pipelines,
         "event_streams": EventStreamCommand,

--- a/origocli/commands/eventsng/__init__.py
+++ b/origocli/commands/eventsng/__init__.py
@@ -1,0 +1,3 @@
+from .events import Events
+
+__all__ = ["Events"]

--- a/origocli/commands/eventsng/base.py
+++ b/origocli/commands/eventsng/base.py
@@ -1,0 +1,8 @@
+from origocli.command import BaseCommand
+
+
+class BaseEventsCommand(BaseCommand):
+    def __init__(self, sdk):
+        super().__init__()
+        self.sdk = sdk
+        self.handler = self.default

--- a/origocli/commands/eventsng/events.py
+++ b/origocli/commands/eventsng/events.py
@@ -1,0 +1,57 @@
+from origo.event.event_stream_client import EventStreamClient
+
+from origocli.command import BaseCommand
+from origocli.commands.eventsng.streams import (
+    EventsCreateStream,
+    EventsLs,
+    EventsDeleteStream,
+)
+from origocli.commands.eventsng.subscribable import (
+    EventsCheckSubscribable,
+    EventsEnableSubscribable,
+    EventsDisableSubscribable,
+)
+from origocli.commands.eventsng.sinks import (
+    EventsLsSinks,
+    EventsAddSink,
+    EventsRemoveSink,
+)
+
+
+class Events(BaseCommand):
+    """
+    usage:
+      origo eventsng create-stream <datasetid> <version> [--skip-raw] [options]
+      origo eventsng ls <datasetid> <version> [options]
+      origo eventsng delete-stream <datasetid> <version> [options]
+      origo eventsng check-subscribable <datasetid> <version> [options]
+      origo eventsng enable-subscribable <datasetid> <version> [options]
+      origo eventsng disable-subscribable <datasetid> <version> [options]
+      origo eventsng sinks <datasetid> <version> [--sink-id=<sink_id>] [options]
+      origo eventsng add-sink <datasetid> <version> --sink-type=<sink_type> [options]
+      origo eventsng remove-sink <datasetid> <version> --sink-id=<sink_id> [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.sdk = EventStreamClient()
+        self.sdk.login()
+        self.handler = self.default
+        self.sub_commands = [
+            EventsCreateStream,
+            EventsLs,
+            EventsDeleteStream,
+            EventsCheckSubscribable,
+            EventsEnableSubscribable,
+            EventsDisableSubscribable,
+            EventsLsSinks,
+            EventsAddSink,
+            EventsRemoveSink,
+        ]
+
+    def default(self):
+        self.help()

--- a/origocli/commands/eventsng/sinks.py
+++ b/origocli/commands/eventsng/sinks.py
@@ -20,17 +20,12 @@ class EventsLsSinks(BaseEventsCommand):
 
         if sink_id:
             out.output_singular_object = True
-            # data = self.sdk.get_sink(datasetid, versionid, sink_id)
-            data = {"status": "ACTIVE", "type": "elasticsearch", "id": "ujw6g"}
+            data = self.sdk.get_sink(datasetid, version, sink_id)
             out.add_row(data)
             self.print(f"Sink for {datasetid}/{version}", out)
             return
 
-        # data = self.sdk.get_sinks(datasetid, versionid)
-        data = [
-            {"status": "ACTIVE", "type": "elasticsearch", "id": "ujw6g"},
-            {"status": "ACTIVE", "type": "s3", "id": "aasd2"},
-        ]
+        data = self.sdk.get_sinks(datasetid, version)
         out.add_rows(data)
         self.print(f"Sinks for {datasetid}/{version}", out)
 
@@ -52,8 +47,7 @@ class EventsAddSink(BaseEventsCommand):
 
         out = create_output(self.opt("format"), "events_sink_config.json")
         out.output_singular_object = True
-        # data = self.sdk.add_sink(datasetid, versionid, sink_type=sink_type)
-        data = {"status": "ACTIVE", "type": sink_type, "id": "ujw6g"}
+        data = self.sdk.add_sink(datasetid, version, sink_type=sink_type)
         out.add_row(data)
         self.print(f"Adding sink for {datasetid}/{version}", out)
 
@@ -75,6 +69,5 @@ class EventsRemoveSink(BaseEventsCommand):
 
         out = create_output(self.opt("format"), "events_sink_config.json")
         out.output_singular_object = True
-        # data = self.sdk.remove_sink(datasetid, versionid, sink_id=sink_id)
-        data = {"message": f"Deleted sink {sink_id} from stream {datasetid}/{version}"}
+        data = self.sdk.remove_sink(datasetid, version, sink_id=sink_id)
         self.print(data["message"])

--- a/origocli/commands/eventsng/sinks.py
+++ b/origocli/commands/eventsng/sinks.py
@@ -1,0 +1,80 @@
+from origocli.output import create_output
+from origocli.commands.eventsng.base import BaseEventsCommand
+
+
+class EventsLsSinks(BaseEventsCommand):
+    """
+    usage:
+      origo eventsng sinks <datasetid> <version> [--sink-id=<sink_id>] [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def default(self):
+        datasetid = self.arg("datasetid")
+        version = self.arg("version")
+        sink_id = self.opt("sink-id")
+        out = create_output(self.opt("format"), "events_sink_config.json")
+
+        if sink_id:
+            out.output_singular_object = True
+            # data = self.sdk.get_sink(datasetid, versionid, sink_id)
+            data = {"status": "ACTIVE", "type": "elasticsearch", "id": "ujw6g"}
+            out.add_row(data)
+            self.print(f"Sink for {datasetid}/{version}", out)
+            return
+
+        # data = self.sdk.get_sinks(datasetid, versionid)
+        data = [
+            {"status": "ACTIVE", "type": "elasticsearch", "id": "ujw6g"},
+            {"status": "ACTIVE", "type": "s3", "id": "aasd2"},
+        ]
+        out.add_rows(data)
+        self.print(f"Sinks for {datasetid}/{version}", out)
+
+
+class EventsAddSink(BaseEventsCommand):
+    """
+    usage:
+      origo eventsng add-sink <datasetid> <version> --sink-type=<sink_type> [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def default(self):
+        datasetid = self.arg("datasetid")
+        version = self.arg("version")
+        sink_type = self.opt("sink-type")
+
+        out = create_output(self.opt("format"), "events_sink_config.json")
+        out.output_singular_object = True
+        # data = self.sdk.add_sink(datasetid, versionid, sink_type=sink_type)
+        data = {"status": "ACTIVE", "type": sink_type, "id": "ujw6g"}
+        out.add_row(data)
+        self.print(f"Adding sink for {datasetid}/{version}", out)
+
+
+class EventsRemoveSink(BaseEventsCommand):
+    """
+    usage:
+      origo eventsng remove-sink <datasetid> <version> --sink-id=<sink_id> [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def default(self):
+        datasetid = self.arg("datasetid")
+        version = self.arg("version")
+        sink_id = self.opt("sink-id")
+
+        out = create_output(self.opt("format"), "events_sink_config.json")
+        out.output_singular_object = True
+        # data = self.sdk.remove_sink(datasetid, versionid, sink_id=sink_id)
+        data = {"message": f"Deleted sink {sink_id} from stream {datasetid}/{version}"}
+        self.print(data["message"])

--- a/origocli/commands/eventsng/sinks.py
+++ b/origocli/commands/eventsng/sinks.py
@@ -20,7 +20,7 @@ class EventsLsSinks(BaseEventsCommand):
 
         if sink_id:
             out.output_singular_object = True
-            data = self.sdk.get_sink(datasetid, version, sink_id)
+            data = self.sdk.get_sink(datasetid, version, sink_id=sink_id)
             out.add_row(data)
             self.print(f"Sink for {datasetid}/{version}", out)
             return
@@ -67,7 +67,5 @@ class EventsRemoveSink(BaseEventsCommand):
         version = self.arg("version")
         sink_id = self.opt("sink-id")
 
-        out = create_output(self.opt("format"), "events_sink_config.json")
-        out.output_singular_object = True
         data = self.sdk.remove_sink(datasetid, version, sink_id=sink_id)
         self.print(data["message"])

--- a/origocli/commands/eventsng/streams.py
+++ b/origocli/commands/eventsng/streams.py
@@ -1,0 +1,80 @@
+from origocli.output import create_output
+from origocli.commands.eventsng.base import BaseEventsCommand
+
+# ############ TODO: REMOVE
+# data = {
+#     "status": "ACTIVE",
+#     "updated_by": "janedoe",
+#     "updated_at": "2020-08-26T08:07:21.903672+00:00",
+#     "id": "vannmalinger-fra-lmc-test/1",
+#     "create_raw": True,
+#     "deleted": False,
+#     "confidentiality": "yellow",
+# }
+# ############ TODO: REMOVE
+
+
+class EventsCreateStream(BaseEventsCommand):
+    """
+    usage:
+      origo eventsng create-stream <datasetid> <version> [--skip-raw] [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def default(self):
+        out = create_output(self.opt("format"), "events_stream_config.json")
+        out.output_singular_object = True
+        datasetid = self.arg("datasetid")
+        version = self.arg("version")
+        create_raw = not self.opt("skip-raw")
+        self.log.info(
+            f"Creating event stream for dataset {datasetid}/{version}, raw={create_raw}"
+        )
+        data = self.sdk.create_event_stream(datasetid, version, create_raw=create_raw)
+        out.add_row(data)
+        self.print(f"Creating event stream for {datasetid}/{version}", out)
+
+
+class EventsLs(BaseEventsCommand):
+    """
+    usage:
+      origo eventsng ls <datasetid> <version> [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def default(self):
+        out = create_output(self.opt("format"), "events_stream_config.json")
+        out.output_singular_object = True
+        datasetid = self.arg("datasetid")
+        version = self.arg("version")
+        self.log.info(f"Getting event stream for dataset {datasetid}/{version}")
+        data = self.sdk.get_event_stream_info(datasetid, version)
+        out.add_row(data)
+        self.print(f"Event streams for {datasetid}/{version}", out)
+
+
+class EventsDeleteStream(BaseEventsCommand):
+    """
+    usage:
+      origo eventsng delete-stream <datasetid> <version> [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def default(self):
+        out = create_output(self.opt("format"), "events_stream_config.json")
+        out.output_singular_object = True
+        datasetid = self.arg("datasetid")
+        version = self.arg("version")
+        self.log.info(f"Deleting event stream for dataset {datasetid}/{version}")
+        data = self.sdk.delete_event_stream(datasetid, version)
+        out.add_row(data)
+        self.print(f"Deleting event stream for {datasetid}/{version}", out)

--- a/origocli/commands/eventsng/streams.py
+++ b/origocli/commands/eventsng/streams.py
@@ -1,18 +1,6 @@
 from origocli.output import create_output
 from origocli.commands.eventsng.base import BaseEventsCommand
 
-# ############ TODO: REMOVE
-# data = {
-#     "status": "ACTIVE",
-#     "updated_by": "janedoe",
-#     "updated_at": "2020-08-26T08:07:21.903672+00:00",
-#     "id": "vannmalinger-fra-lmc-test/1",
-#     "create_raw": True,
-#     "deleted": False,
-#     "confidentiality": "yellow",
-# }
-# ############ TODO: REMOVE
-
 
 class EventsCreateStream(BaseEventsCommand):
     """

--- a/origocli/commands/eventsng/subscribable.py
+++ b/origocli/commands/eventsng/subscribable.py
@@ -1,0 +1,64 @@
+from origocli.output import create_output
+from origocli.commands.eventsng.base import BaseEventsCommand
+
+
+class EventsCheckSubscribable(BaseEventsCommand):
+    """
+    usage:
+      origo eventsng check-subscribable <datasetid> <version> [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def default(self):
+        out = create_output(self.opt("format"), "events_subscribable_config.json")
+        out.output_singular_object = True
+        datasetid = self.arg("datasetid")
+        version = self.arg("version")
+        data = self.sdk.get_subscribable(datasetid, version)
+        out.add_row(data)
+        self.print(f"Subscribable event stream for {datasetid}/{version}", out)
+
+
+class EventsEnableSubscribable(BaseEventsCommand):
+    """
+    usage:
+      origo eventsng enable-subscribable <datasetid> <version> [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def default(self):
+        out = create_output(self.opt("format"), "events_subscribable_config.json")
+        out.output_singular_object = True
+        datasetid = self.arg("datasetid")
+        version = self.arg("version")
+        data = self.sdk.enable_subscribable(datasetid, version)
+        out.add_row(data)
+        self.print(f"Enabling subscribable event stream for {datasetid}/{version}", out)
+
+
+class EventsDisableSubscribable(BaseEventsCommand):
+    """
+    usage:
+      origo eventsng disable-subscribable <datasetid> <version> [options]
+
+    options:
+      -d --debug
+      --format=<format>
+    """
+
+    def default(self):
+        out = create_output(self.opt("format"), "events_subscribable_config.json")
+        out.output_singular_object = True
+        datasetid = self.arg("datasetid")
+        version = self.arg("version")
+        data = self.sdk.disable_subscribable(datasetid, version)
+        out.add_row(data)
+        self.print(
+            f"Disabling subscribable event stream for {datasetid}/{version}", out
+        )

--- a/origocli/data/output-format/events_sink_config.json
+++ b/origocli/data/output-format/events_sink_config.json
@@ -1,0 +1,15 @@
+{
+  "Id": {
+    "name": "Id",
+    "key": "id"
+  },
+  "Type": {
+    "name": "Type",
+    "key": "type"
+  },
+  "Status": {
+    "name": "Status",
+    "key": "status"
+  }
+}
+  

--- a/origocli/data/output-format/events_sink_config.json
+++ b/origocli/data/output-format/events_sink_config.json
@@ -10,6 +10,14 @@
   "Status": {
     "name": "Status",
     "key": "status"
+  },
+  "UpdatedBy": {
+    "name": "Updated by",
+    "key": "updated_by"
+  },
+  "CreatedAt": {
+    "name": "Updated date",
+    "key": "updated_at"
   }
 }
   

--- a/origocli/data/output-format/events_stream_config.json
+++ b/origocli/data/output-format/events_stream_config.json
@@ -1,0 +1,30 @@
+{
+  "ID": {
+    "name": "Stream ID",
+    "key": "id"
+  },
+  "Raw": {
+    "name": "Raw",
+    "key": "create_raw"
+  },
+  "Confidentiality": {
+    "name": "Confidentiality",
+    "key": "confidentiality"
+  },
+  "UpdatedBy": {
+    "name": "Updated by",
+    "key": "updated_by"
+  },
+  "CreatedAt": {
+    "name": "Updated date",
+    "key": "updated_at"
+  },
+  "Deleted": {
+    "name": "Deleted",
+    "key": "deleted"
+  },
+  "Status": {
+    "name": "Status",
+    "key": "status"
+  }
+}

--- a/origocli/data/output-format/events_stream_config.json
+++ b/origocli/data/output-format/events_stream_config.json
@@ -11,14 +11,6 @@
     "name": "Confidentiality",
     "key": "confidentiality"
   },
-  "UpdatedBy": {
-    "name": "Updated by",
-    "key": "updated_by"
-  },
-  "CreatedAt": {
-    "name": "Updated date",
-    "key": "updated_at"
-  },
   "Deleted": {
     "name": "Deleted",
     "key": "deleted"
@@ -26,5 +18,13 @@
   "Status": {
     "name": "Status",
     "key": "status"
+  },
+  "UpdatedBy": {
+    "name": "Updated by",
+    "key": "updated_by"
+  },
+  "CreatedAt": {
+    "name": "Updated date",
+    "key": "updated_at"
   }
 }

--- a/origocli/data/output-format/events_subscribable_config.json
+++ b/origocli/data/output-format/events_subscribable_config.json
@@ -1,12 +1,4 @@
 {
-  "UpdatedBy": {
-    "name": "Updated by",
-    "key": "updated_by"
-  },
-  "CreatedAt": {
-    "name": "Updated date",
-    "key": "updated_at"
-  },
   "Deleted": {
     "name": "Enabled",
     "key": "enabled"
@@ -14,5 +6,13 @@
   "Status": {
     "name": "Status",
     "key": "status"
+  },
+  "UpdatedBy": {
+    "name": "Updated by",
+    "key": "updated_by"
+  },
+  "CreatedAt": {
+    "name": "Updated date",
+    "key": "updated_at"
   }
 }

--- a/origocli/data/output-format/events_subscribable_config.json
+++ b/origocli/data/output-format/events_subscribable_config.json
@@ -1,0 +1,18 @@
+{
+  "UpdatedBy": {
+    "name": "Updated by",
+    "key": "updated_by"
+  },
+  "CreatedAt": {
+    "name": "Updated date",
+    "key": "updated_at"
+  },
+  "Deleted": {
+    "name": "Enabled",
+    "key": "enabled"
+  },
+  "Status": {
+    "name": "Status",
+    "key": "status"
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
         "PrettyTable",
         "docopt",
         "requests",
-        "origo-sdk-python>=0.2.2",
+        "origo-sdk-python>=0.2.4",
         "inquirer",
         "fuzzywuzzy",
         "python-Levenshtein",

--- a/tests/origocli/commands/eventsng_test.py
+++ b/tests/origocli/commands/eventsng_test.py
@@ -9,16 +9,17 @@ from origocli.commands.eventsng.streams import (
     EventsDeleteStream,
 )
 
-# from origocli.commands.eventsng.subscribable import (
-#     EventsCheckSubscribable,
-#     EventsEnableSubscribable,
-#     EventsDisableSubscribable,
-# )
-# from origocli.commands.eventsng.sinks import (
-#     EventsLsSinks,
-#     EventsAddSink,
-#     EventsRemoveSink,
-# )
+from origocli.commands.eventsng.subscribable import (
+    EventsCheckSubscribable,
+    EventsEnableSubscribable,
+    EventsDisableSubscribable,
+)
+
+from origocli.commands.eventsng.sinks import (
+    EventsLsSinks,
+    EventsAddSink,
+    EventsRemoveSink,
+)
 
 
 event_stream_client_qual = (
@@ -27,6 +28,7 @@ event_stream_client_qual = (
 sdk = EventStreamClient()
 dataset_id = "test-dataset"
 version = "1"
+sink_id = "abc123"
 event_stream_item = {
     "status": "ACTIVE",
     "updated_by": "knut",
@@ -41,6 +43,16 @@ subscribable_item = {
     "updated_by": "janedone",
     "updated_at": "2020-08-20T06:51:42.786699+00:00",
     "enabled": False,
+}
+sink_item = {
+    "id": sink_id,
+    "type": "s3",
+    "status": "ACTIVE",
+    "updated_by": "janedone",
+    "updated_at": "2020-08-20T06:51:42.786699+00:00",
+}
+sink_deleted_response = {
+    "message": f"Deleted sink {sink_id} from stream {dataset_id}/{version}"
 }
 
 
@@ -71,7 +83,7 @@ class TestEventsCreateStream:
         )
         assert (
             capsys.readouterr().out.strip()
-            == '{"id": "test-dataset/1", "create_raw": true, "confidentiality": "yellow", "updated_by": "knut", "updated_at": "2020-08-26T08:07:21.903672+00:00", "deleted": false, "status": "ACTIVE"}'
+            == '{"id": "test-dataset/1", "create_raw": true, "confidentiality": "yellow", "deleted": false, "status": "ACTIVE", "updated_by": "knut", "updated_at": "2020-08-26T08:07:21.903672+00:00"}'
         )
 
 
@@ -103,7 +115,6 @@ class TestEventsDeleteStream:
         mock_print.assert_called_once()
 
 
-"""
 class TestEventsCheckSubscribable:
     def test_check_subscribable(self, mocker, mock_print):
         set_argv("eventsng", "check-subscribable", dataset_id, version)
@@ -112,10 +123,103 @@ class TestEventsCheckSubscribable:
             f"{event_stream_client_qual}.get_subscribable",
             return_value=subscribable_item,
         )
-        EventsCreateStream(sdk).handler()
-        sdk_command.assert_called_once_with(
-            dataset_id, version
-        )
+        EventsCheckSubscribable(sdk).handler()
+        sdk_command.assert_called_once_with(dataset_id, version)
         add_row.assert_called_once_with(self=ANY, row=subscribable_item)
         mock_print.assert_called_once()
-"""
+
+
+class TestEventsEnableSubscribable:
+    def test_enable_subscribable(self, mocker, mock_print):
+        set_argv("eventsng", "enable-subscribable", dataset_id, version)
+        add_row = mocker.spy(TableOutput, "add_row")
+        sdk_command = mocker.patch(
+            f"{event_stream_client_qual}.enable_subscribable",
+            return_value=subscribable_item,
+        )
+        EventsEnableSubscribable(sdk).handler()
+        sdk_command.assert_called_once_with(dataset_id, version)
+        add_row.assert_called_once_with(self=ANY, row=subscribable_item)
+        mock_print.assert_called_once()
+
+
+class TestEventsDisableSubscribable:
+    def test_disable_subscribable(self, mocker, mock_print):
+        set_argv("eventsng", "disable-subscribable", dataset_id, version)
+        add_row = mocker.spy(TableOutput, "add_row")
+        sdk_command = mocker.patch(
+            f"{event_stream_client_qual}.disable_subscribable",
+            return_value=subscribable_item,
+        )
+        EventsDisableSubscribable(sdk).handler()
+        sdk_command.assert_called_once_with(dataset_id, version)
+        add_row.assert_called_once_with(self=ANY, row=subscribable_item)
+        mock_print.assert_called_once()
+
+
+class TestEventsLsSinks:
+    def test_ls_sinks(self, mocker, mock_print):
+        set_argv("eventsng", "sinks", dataset_id, version)
+        add_rows = mocker.spy(TableOutput, "add_rows")
+        sdk_command = mocker.patch(
+            f"{event_stream_client_qual}.get_sinks",
+            return_value=[sink_item],
+        )
+        EventsLsSinks(sdk).handler()
+        sdk_command.assert_called_once_with(dataset_id, version)
+        add_rows.assert_called_once_with(self=ANY, rows=[sink_item])
+        mock_print.assert_called_once()
+
+    def test_ls_sinks_with_id(self, mocker, mock_print):
+        set_argv("eventsng", "sinks", dataset_id, version, "--sink-id", sink_id)
+        add_row = mocker.spy(TableOutput, "add_row")
+        sdk_command = mocker.patch(
+            f"{event_stream_client_qual}.get_sink",
+            return_value=sink_item,
+        )
+        EventsLsSinks(sdk).handler()
+        sdk_command.assert_called_once_with(dataset_id, version, sink_id=sink_id)
+        add_row.assert_called_once_with(self=ANY, row=sink_item)
+        mock_print.assert_called_once()
+
+
+class TestEventsAddSink:
+    def test_add_sink(self, mocker, mock_print):
+        set_argv(
+            "eventsng",
+            "add-sink",
+            dataset_id,
+            version,
+            "--sink-type",
+            sink_item["type"],
+        )
+        add_row = mocker.spy(TableOutput, "add_row")
+        sdk_command = mocker.patch(
+            f"{event_stream_client_qual}.add_sink",
+            return_value=sink_item,
+        )
+        EventsAddSink(sdk).handler()
+        sdk_command.assert_called_once_with(
+            dataset_id, version, sink_type=sink_item["type"]
+        )
+        add_row.assert_called_once_with(self=ANY, row=sink_item)
+        mock_print.assert_called_once()
+
+
+class TestEventsRemoveSink:
+    def test_remove_sink(self, mocker, mock_print):
+        set_argv(
+            "eventsng",
+            "remove-sink",
+            dataset_id,
+            version,
+            "--sink-id",
+            sink_id,
+        )
+        sdk_command = mocker.patch(
+            f"{event_stream_client_qual}.remove_sink",
+            return_value=sink_deleted_response,
+        )
+        EventsRemoveSink(sdk).handler()
+        sdk_command.assert_called_once_with(dataset_id, version, sink_id=sink_id)
+        mock_print.assert_called_once()

--- a/tests/origocli/commands/eventsng_test.py
+++ b/tests/origocli/commands/eventsng_test.py
@@ -1,0 +1,121 @@
+from unittest.mock import ANY
+from conftest import set_argv
+
+from origocli.output import TableOutput
+from origo.event.event_stream_client import EventStreamClient
+from origocli.commands.eventsng.streams import (
+    EventsCreateStream,
+    EventsLs,
+    EventsDeleteStream,
+)
+
+# from origocli.commands.eventsng.subscribable import (
+#     EventsCheckSubscribable,
+#     EventsEnableSubscribable,
+#     EventsDisableSubscribable,
+# )
+# from origocli.commands.eventsng.sinks import (
+#     EventsLsSinks,
+#     EventsAddSink,
+#     EventsRemoveSink,
+# )
+
+
+event_stream_client_qual = (
+    f"{EventStreamClient.__module__}.{EventStreamClient.__name__}"
+)
+sdk = EventStreamClient()
+dataset_id = "test-dataset"
+version = "1"
+event_stream_item = {
+    "status": "ACTIVE",
+    "updated_by": "knut",
+    "updated_at": "2020-08-26T08:07:21.903672+00:00",
+    "id": f"{dataset_id}/{version}",
+    "create_raw": True,
+    "deleted": False,
+    "confidentiality": "yellow",
+}
+subscribable_item = {
+    "status": "INACTIVE",
+    "updated_by": "janedone",
+    "updated_at": "2020-08-20T06:51:42.786699+00:00",
+    "enabled": False,
+}
+
+
+class TestEventsCreateStream:
+    def test_create_stream(self, mocker, mock_print):
+        set_argv("eventsng", "create-stream", dataset_id, version, "--skip-raw")
+        add_row = mocker.spy(TableOutput, "add_row")
+        create_event_stream = mocker.patch(
+            f"{event_stream_client_qual}.create_event_stream",
+            return_value=event_stream_item,
+        )
+        EventsCreateStream(sdk).handler()
+        create_event_stream.assert_called_once_with(
+            dataset_id, version, create_raw=False
+        )
+        add_row.assert_called_once_with(self=ANY, row=event_stream_item)
+        mock_print.assert_called_once()
+
+    def test_create_stream_as_json(self, mocker, capsys):
+        set_argv("eventsng", "create-stream", dataset_id, version, "--format", "json")
+        create_event_stream = mocker.patch(
+            f"{event_stream_client_qual}.create_event_stream",
+            return_value=event_stream_item,
+        )
+        EventsCreateStream(sdk).handler()
+        create_event_stream.assert_called_once_with(
+            dataset_id, version, create_raw=True
+        )
+        assert (
+            capsys.readouterr().out.strip()
+            == '{"id": "test-dataset/1", "create_raw": true, "confidentiality": "yellow", "updated_by": "knut", "updated_at": "2020-08-26T08:07:21.903672+00:00", "deleted": false, "status": "ACTIVE"}'
+        )
+
+
+class TestEventsLs:
+    def test_event_streams(self, mocker, mock_print):
+        set_argv("eventsng", "ls", dataset_id, version)
+        add_row = mocker.spy(TableOutput, "add_row")
+        get_event_stream = mocker.patch(
+            f"{event_stream_client_qual}.get_event_stream_info",
+            return_value=event_stream_item,
+        )
+        EventsLs(sdk).handler()
+        get_event_stream.assert_called_once_with(dataset_id, version)
+        add_row.assert_called_once_with(self=ANY, row=event_stream_item)
+        mock_print.assert_called_once()
+
+
+class TestEventsDeleteStream:
+    def test_delete_stream(self, mocker, mock_print):
+        set_argv("eventsng", "delete-stream", dataset_id, version)
+        add_row = mocker.spy(TableOutput, "add_row")
+        delete_event_stream = mocker.patch(
+            f"{event_stream_client_qual}.delete_event_stream",
+            return_value=event_stream_item,
+        )
+        EventsDeleteStream(sdk).handler()
+        delete_event_stream.assert_called_once_with(dataset_id, version)
+        add_row.assert_called_once_with(self=ANY, row=event_stream_item)
+        mock_print.assert_called_once()
+
+
+"""
+class TestEventsCheckSubscribable:
+    def test_check_subscribable(self, mocker, mock_print):
+        set_argv("eventsng", "check-subscribable", dataset_id, version)
+        add_row = mocker.spy(TableOutput, "add_row")
+        sdk_command = mocker.patch(
+            f"{event_stream_client_qual}.get_subscribable",
+            return_value=subscribable_item,
+        )
+        EventsCreateStream(sdk).handler()
+        sdk_command.assert_called_once_with(
+            dataset_id, version
+        )
+        add_row.assert_called_once_with(self=ANY, row=subscribable_item)
+        mock_print.assert_called_once()
+"""


### PR DESCRIPTION
Add commands for managing event streams using the new `event-stream-api`.  Proposed layout based on the pipeline implementation; final naming for commands to be decided.