### PR TITLE
DP-1119 Use Sphinx for documentation generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 dist/
 *egg-info/
 __pycache__*
+doc/_build/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,7 @@
 # Oslo Origo CLI
 
-Origo CLI provides a unified interface to the services provided by Oslo Origo
+Origo CLI provides a unified interface to the services provided by Oslo Origo.
 
-Content:
-* [Install/setup](doc/install.md)
-  * [Python requirements and setup](doc/python.md)
-* [Configuration](doc/configuration.md)
-* [Datasets](doc/datasets.md)
-* [Events](doc/events.md)
-* [Pipelines](doc/pipelines.md)
-* [Webhooks](doc/webhooks.md)
-
-# Resources
-* [github pages for dataplatform](https://oslokommune.github.io/dataplattform/)
+## Resources
+* [Documentation at Read the Docs](https://origo-cli.readthedocs.io/)
+* [GitHub pages for Origo Dataplatform](https://oslokommune.github.io/dataplattform/)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,54 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "Origo CLI"
+copyright = "2020, Oslo Origo"
+author = "Oslo Origo"
+
+# The full version, including alpha/beta/rc tags
+release = "0.3.1"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ["recommonmark"]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "alabaster"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,15 @@
+# Oslo Origo CLI
+
+Origo CLI provides a unified interface to the services provided by Oslo Origo.
+
+Content:
+* [Install/setup](install.md)
+  * [Python requirements and setup](python.md)
+* [Configuration](configuration.md)
+* [Datasets](datasets.md)
+* [Events](events.md)
+* [Pipelines](pipelines.md)
+* [Webhooks](webhooks.md)
+
+## Resources
+* [GitHub pages for Origo Dataplatform](https://oslokommune.github.io/dataplattform/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,29 +4,48 @@
 #
 #    pip-compile
 #
+alabaster==0.7.12         # via sphinx
 attrs==19.3.0             # via jsonschema
+babel==2.8.0              # via sphinx
 blessings==1.7            # via inquirer
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
+commonmark==0.9.1         # via recommonmark
 docopt==0.6.2             # via origo-cli (setup.py)
+docutils==0.16            # via recommonmark, sphinx
 ecdsa==0.15               # via python-jose
 idna==2.9                 # via requests
+imagesize==1.2.0          # via sphinx
 importlib-metadata==1.6.0  # via jsonschema
 inquirer==2.6.3           # via origo-cli (setup.py)
+jinja2==2.11.2            # via sphinx
 jsonschema==3.2.0         # via origo-sdk-python
+markupsafe==1.1.1         # via jinja2
 origo-sdk-python==0.2.2   # via origo-cli (setup.py)
+packaging==20.4           # via sphinx
 prettytable==0.7.2        # via origo-cli (setup.py), origo-sdk-python
 pyasn1==0.4.8             # via python-jose, rsa
-pygments==2.6.1           # via origo-cli (setup.py)
+pygments==2.6.1           # via origo-cli (setup.py), sphinx
 pyjwt==1.7.1              # via origo-sdk-python
+pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via jsonschema
 python-editor==1.0.4      # via inquirer
 python-jose==3.1.0        # via python-keycloak
 python-keycloak==0.20.0   # via origo-sdk-python
+pytz==2020.1              # via babel
 readchar==2.0.1           # via inquirer
-requests==2.23.0          # via origo-cli (setup.py), origo-sdk-python, python-keycloak
+recommonmark==0.6.0       # via origo-cli (setup.py)
+requests==2.23.0          # via origo-cli (setup.py), origo-sdk-python, python-keycloak, sphinx
 rsa==4.0                  # via python-jose
-six==1.14.0               # via blessings, ecdsa, jsonschema, pyrsistent, python-jose
+six==1.14.0               # via blessings, ecdsa, jsonschema, packaging, pyrsistent, python-jose
+snowballstemmer==2.0.0    # via sphinx
+sphinx==3.2.1             # via origo-cli (setup.py), recommonmark
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
+sphinxcontrib-jsmath==1.0.1  # via sphinx
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 urllib3==1.25.9           # via origo-sdk-python, requests
 zipp==3.1.0               # via importlib-metadata
 

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,13 @@ setuptools.setup(
     },
     install_requires=[
         "PrettyTable",
+        "Sphinx",
         "docopt",
-        "requests",
-        "origo-sdk-python>=0.2.2",
         "inquirer",
+        "origo-sdk-python>=0.2.2",
         "pygments",
+        "recommonmark",
+        "requests",
     ],
     entry_points={"console_scripts": ["origo=bin.cli:main"]},
     classifiers=[


### PR DESCRIPTION
Use Sphinx to render the documentation, making it suitable for hosting at readthedocs.org.

A preview can be found at https://origo-cli.readthedocs.io/en/readthedocs/.