### PR TITLE
DP-1269 Expand `~` to home directory in `--file` args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## ?.?.?
+
+* `~` is now expanded to the home directory in arguments to the `--file` option,
+  such as in `origo datasets create --file=~/Documents/my-dataset.json`.
+
 ## 0.4.0
 
 * New syntax for the `origo datasets cp` command. Four different URI formats are

--- a/origocli/commands/datasets/datasets.py
+++ b/origocli/commands/datasets/datasets.py
@@ -3,7 +3,7 @@ from requests.exceptions import HTTPError
 from origocli.command import BaseCommand, BASE_COMMAND_OPTIONS
 from origocli.commands.datasets import DatasetsBoilerplateCommand
 from origocli.output import create_output
-from origocli.io import read_stdin_or_filepath, resolve_output_filepath
+from origocli.io import read_json, resolve_output_filepath
 from origocli.date import date_now, DATE_METADATA_EDITION_FORMAT
 
 from origo.data.dataset import Dataset
@@ -125,7 +125,7 @@ Options:{BASE_COMMAND_OPTIONS}
         self.print(f"\n\nLatest version for: {dataset_id}", out)
 
     def create_dataset(self):
-        payload = read_stdin_or_filepath(self.opt("file"))
+        payload = read_json(self.opt("file"))
         self.log.info(f"Creating dataset with payload: {payload}")
 
         dataset = self.sdk.create_dataset(payload)
@@ -154,7 +154,7 @@ Options:{BASE_COMMAND_OPTIONS}
 
     def create_version(self):
         dataset_id = self.arg("datasetid")
-        payload = read_stdin_or_filepath(self.opt("file"))
+        payload = read_json(self.opt("file"))
         self.log.info(
             f"Creating version for dataset: {dataset_id} with payload: {payload}"
         )
@@ -200,7 +200,7 @@ Options:{BASE_COMMAND_OPTIONS}
         self.print("Files available: ", out)
 
     def create_edition(self):
-        payload = read_stdin_or_filepath(self.opt("file"))
+        payload = read_json(self.opt("file"))
         dataset_id = self.arg("datasetid")
         version_id = self.resolve_or_load_versionid(dataset_id)
         self.log.info(
@@ -252,7 +252,7 @@ Options:{BASE_COMMAND_OPTIONS}
     # Distribution
     # #################################### #
     def create_distribution(self):
-        payload = read_stdin_or_filepath(self.opt("file"))
+        payload = read_json(self.opt("file"))
         dataset_id = self.arg("datasetid")
         version_id = self.resolve_or_load_versionid(dataset_id)
         edition_id = self.resolve_or_create_edition(dataset_id, version_id)

--- a/origocli/commands/events.py
+++ b/origocli/commands/events.py
@@ -4,7 +4,7 @@ from origo.event.post_event import PostEvent
 from origo.elasticsearch.queries import ElasticsearchQueries
 
 from origocli.command import BaseCommand, BASE_COMMAND_OPTIONS
-from origocli.io import read_stdin_or_filepath
+from origocli.io import read_json
 from origocli.output import create_output
 
 
@@ -54,7 +54,7 @@ Options:{BASE_COMMAND_OPTIONS}
     def put_event(self):
         out = create_output(self.opt("format"), "event_stream_put_config.json")
         out.output_singular_object = True
-        payload = read_stdin_or_filepath(self.opt("file"))
+        payload = read_json(self.opt("file"))
         self.log.info(f"Putting event with payload: {payload}")
 
         datasetid = self.arg("datasetid")

--- a/origocli/io.py
+++ b/origocli/io.py
@@ -1,25 +1,23 @@
-import sys
 import json
 import logging
 import os
+import sys
 
 log = logging.getLogger()
 
 
-def read_stdin_or_filepath(file):
-    payload = None
-    if file is not None:
-        log.info(f"Reading data from file: {file}")
-        with open(file) as f:
-            payload = json.load(f)
-    else:
-        log.info("Reading data from stdin")
-        data = ""
-        for i, dataline in enumerate(sys.stdin, start=1):
-            data = f"{data}\n{dataline}"
-        payload = json.loads(data)
-    # TODO: raise DataNotFoundException()
-    return payload
+def read_json(filename=None):
+    """Read JSON data from a file named `filename`.
+
+    If no filename is given, the data is read from stdin instead.
+    """
+    if filename:
+        log.info(f"Reading data from file: {filename}")
+        with open(os.path.expanduser(filename)) as f:
+            return json.load(f)
+
+    log.info("Reading data from stdin")
+    return json.loads(sys.stdin.read())
 
 
 def resolve_output_filepath(target):

--- a/tests/origocli/commands/events_test.py
+++ b/tests/origocli/commands/events_test.py
@@ -14,7 +14,7 @@ def test_handler(mocker):
     set_argv("events", "put", "dataset-id", "version-1", "--file", "input.json")
     input_json = {"test": "event"}
     read_input = mocker.patch(
-        f"{EventsCommand.__module__}.read_stdin_or_filepath", return_value=input_json
+        f"{EventsCommand.__module__}.read_json", return_value=input_json
     )
     post_event = mocker.patch(
         f"{pipeline_client_qual}.post_event", return_value={"some": "response"}

--- a/tests/origocli/io_test.py
+++ b/tests/origocli/io_test.py
@@ -1,0 +1,30 @@
+import io
+import os
+import pathlib
+import tempfile
+
+from origocli.io import read_json
+
+
+def test_read_json_from_file():
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(b'{"foo": "bar"}')
+        f.seek(0)
+
+        assert read_json(f.name) == {"foo": "bar"}
+
+
+def test_read_json_from_homedir():
+    with tempfile.NamedTemporaryFile(dir=pathlib.Path.home()) as f:
+        f.write(b'{"foo": "bar"}')
+        f.seek(0)
+
+        filename = "~/{}".format(os.path.basename(f.name))
+
+        assert read_json(filename) == {"foo": "bar"}
+
+
+def test_read_json_from_stdin(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO('{"foo": "bar"}'))
+
+    assert read_json() == {"foo": "bar"}


### PR DESCRIPTION
Expand `~` to the home directory in arguments to the `--file` option, such as in `origo datasets create --file=~/Documents/my-dataset.json`.