### PR TITLE
DP-1287 Include missing datafiles in distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## ?.?.?
+
+* All datafiles required by the boilerplate command are now included in the
+  package distribution.
+
 ## 0.5.0
 
 * Support new event stream API (including updated SDK). Existing sub-commands from `events` and `event_streams` are now combined into `events`, and new commands for managing event stream sinks and subscriptions are added.

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ setuptools.setup(
             "data/boilerplate/data/*",
             "data/boilerplate/dataset/*",
             "data/boilerplate/pipeline/*",
+            "data/boilerplate/pipeline/csv-to-parquet/*",
+            "data/boilerplate/pipeline/data-copy/*",
             "data/output-format/*",
         ],
     },


### PR DESCRIPTION
Include all datafiles required by the boilerplate command in the package distribution.