### PR TITLE
Port boilerplate script to the new `cp` syntax

### DIFF
--- a/origocli/data/boilerplate/bin/run.sh
+++ b/origocli/data/boilerplate/bin/run.sh
@@ -110,7 +110,7 @@ fi
 echo "Created input for $dataset_id"
 
 ######### Copy file to dataset #########
-upload=`origo datasets cp $dataset_upload_file ds:$dataset_id $version_id $edition_id --format=json`
+upload=`origo datasets cp $dataset_upload_file ds:$dataset_id/$version_id/$edition_id --format=json`
 error=`echo $upload | jq -r '.error'`
 if [[ "$error" =~ ^[1]+$ ]]; then
   echo "Could not upload file"


### PR DESCRIPTION
The syntax of the `datasets cp` command was changed in e276485506efdeefe1635b4bdc0e49142a7782f1 to use dataset URIs instead of positional arguments. Update the boilerplate script accordingly.