### PR TITLE
DP-1320 Don't prompt for account ID in boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## ?.?.?
 
+* The boilerplate command no longer prompts for an AWS account ID.
+
 * The questions on dataset access rights and confidentiality have been unified
   in the boilerplate questionnaire.
 

--- a/origocli/commands/datasets/boilerplate/boilerplate.py
+++ b/origocli/commands/datasets/boilerplate/boilerplate.py
@@ -95,7 +95,6 @@ Options:{BASE_COMMAND_OPTIONS}
         run_file_path = f"{outdir}/run.sh"
         with open(run_file_path) as run_file:
             data = run_file.read()
-            data = data.replace('ACCOUNT_ID=""', f"ACCOUNT_ID=\"{config['id']}\"")
             data = data.replace('echo "### Comment', '# echo "### Comment')
             if self.opt("file"):
                 data = data.replace("hello_world.csv", self.opt("file"))

--- a/origocli/commands/datasets/boilerplate/config.py
+++ b/origocli/commands/datasets/boilerplate/config.py
@@ -2,7 +2,6 @@ from questionary import Choice
 
 from .validator import (
     DateValidator,
-    EnvironmentValidator,
     KeywordValidator,
     PhoneValidator,
     SimpleEmailValidator,
@@ -11,12 +10,6 @@ from .validator import (
 
 available_pipelines = ["data-copy", "csv-to-parquet"]
 boilerplate_questions = [
-    {
-        "type": "text",
-        "name": "id",
-        "message": "Kjøremiljø ID (Som gitt til deg av Origo)",
-        "validate": EnvironmentValidator,
-    },
     {"type": "text", "name": "title", "message": "Tittel", "validate": TitleValidator},
     {"type": "text", "name": "description", "message": "Beskrivelse"},
     {"type": "text", "name": "objective", "message": "Objektiv"},

--- a/origocli/commands/datasets/boilerplate/validator.py
+++ b/origocli/commands/datasets/boilerplate/validator.py
@@ -39,15 +39,6 @@ class PhoneValidator(Validator):
             )
 
 
-class EnvironmentValidator(Validator):
-    def validate(self, document):
-        if not re.match(r"^[0-9]+$", document.text) or len(document.text) != 12:
-            raise ValidationError(
-                message="Valid environment ID, as provided by Origo, 12 characters. Example: 123456789876",
-                cursor_position=len(document.text),
-            )
-
-
 class TitleValidator(Validator):
     def validate(self, document):
         if len(document.text) < 5:

--- a/origocli/commands/pipelines/instances.py
+++ b/origocli/commands/pipelines/instances.py
@@ -83,8 +83,9 @@ class PipelineInstancesCreate(BasePipelinesCommand):
         data = {
             "id": json.loads(resource),
             "datasetUri": originaldata["datasetUri"],
-            "pipelineArn": originaldata["pipelineArn"],
         }
+        if "pipelineProcessorId" in originaldata:
+            data["pipelineProcessorId"] = originaldata["pipelineProcessorId"]
         out.output_singular_object = True
         out.add_row(data)
         self.print("Created resources", out)

--- a/origocli/data/boilerplate/bin/run.sh
+++ b/origocli/data/boilerplate/bin/run.sh
@@ -19,14 +19,6 @@ fi
 echo "Update json files in this directory before running"
 echo "### Comment out this line to run ###\n" && exit 1
 
-# The ACCOUNT_ID is different from ORIGO_ENVIRONMENT=dev and ORIGO_ENVIRONMENT=prod
-# Make sure to use the correct ID as supplied by Origo
-ACCOUNT_ID=""
-if [ "$ACCOUNT_ID" = '' ]; then
-  echo "Update ACCOUNT_ID in this script to the one provided by Origo, then run this script again"
-  exit 1
-fi
-
 echo "Creating a dataset, edition, pipeline and uploading a file to test"
 echo "Please wait....."
 
@@ -83,10 +75,10 @@ edition_id=`echo $edition_id | cut -d "/" -f 3`
 echo "Created edition: $edition_id"
 
 ######### Pipeline instance #########
-cat $pipeline_instance_file | sed "s/DATASET_ID/$dataset_id/" | sed "s/DATASET_VERSION/$version_id/" | sed "s/ACCOUNT_ID/$ACCOUNT_ID/" > generated_pipeline.json
+cat $pipeline_instance_file | sed "s/DATASET_ID/$dataset_id/" | sed "s/DATASET_VERSION/$version_id/" > generated_pipeline.json
 pipeline=`origo pipelines instances create generated_pipeline.json --format=json`
 if [[ $pipeline == "" ]]; then
-    echo "Could not create pipeline instance - did you enter correct account id?"
+    echo "Could not create pipeline instance"
     exit
 fi
 error=`echo $pipeline | jq -r '.error'`

--- a/origocli/data/boilerplate/pipeline/csv-to-parquet/pipeline.json
+++ b/origocli/data/boilerplate/pipeline/csv-to-parquet/pipeline.json
@@ -1,5 +1,5 @@
 {
-  "pipelineArn": "arn:aws:states:eu-west-1:ACCOUNT_ID:stateMachine:dataplatform-csv-to-parquet",
+  "pipelineProcessorId": "dataplatform-csv-to-parquet",
   "taskConfig": {
     "csv_validator": {
       "schema": "",

--- a/origocli/data/boilerplate/pipeline/data-copy/pipeline.json
+++ b/origocli/data/boilerplate/pipeline/data-copy/pipeline.json
@@ -1,5 +1,5 @@
 {
-  "pipelineArn": "arn:aws:states:eu-west-1:ACCOUNT_ID:stateMachine:dataplatform-data-copy",
+  "pipelineProcessorId": "dataplatform-data-copy",
   "taskConfig": {
     "write_to_processed": {
       "output_stage": "processed"

--- a/tests/origocli/commands/datasets/boilerplate/validator_test.py
+++ b/tests/origocli/commands/datasets/boilerplate/validator_test.py
@@ -4,10 +4,10 @@ from questionary import ValidationError
 
 from origocli.commands.datasets.boilerplate.validator import (
     DateValidator,
-    SimpleEmailValidator,
-    PhoneValidator,
-    EnvironmentValidator,
     KeywordValidator,
+    PhoneValidator,
+    SimpleEmailValidator,
+    TitleValidator,
 )
 
 # Note: no testing of return values since the validator is only
@@ -71,28 +71,9 @@ class TestPhoneValidator:
             self.validate_phone({"text": ""})
 
 
-class TestEnvironmentValidator:
-    def validate_environment(self, data):
-        validator = EnvironmentValidator()
-        document = SimpleNamespace(**data)
-        validator.validate(document)
-
-    def test_too_short_environemnt(self):
-        with pytest.raises(ValidationError):
-            self.validate_environment({"text": "12345678912"})
-
-    def test_too_long_environment(self):
-        with pytest.raises(ValidationError):
-            self.validate_environment({"text": "1234567891234"})
-
-    def test_invalid_environment(self):
-        with pytest.raises(ValidationError):
-            self.validate_environment({"text": "12345678912d"})
-
-
 class TestTitleValidator:
     def validate_title(self, data):
-        validator = EnvironmentValidator()
+        validator = TitleValidator()
         document = SimpleNamespace(**data)
         validator.validate(document)
 


### PR DESCRIPTION
Don't prompt for an AWS account ID in the boilerplate command. This is no longer needed once pipeline processors can be referenced by their ID instead of their full ARN (which includes the AWS account ID).