### PR TITLE
DP-1320 Don't ask twice about access rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## ?.?.?
+
+* The questions on dataset access rights and confidentiality have been unified
+  in the boilerplate questionnaire.
+
+* The boilerplate script now uses the new `datasets cp` syntax for file
+  uploading.
+
 ## 0.5.1
 
 * A bug that made the `origo events put` command unusable has been fixed.

--- a/origocli/commands/datasets/boilerplate/boilerplate.py
+++ b/origocli/commands/datasets/boilerplate/boilerplate.py
@@ -9,6 +9,12 @@ from origocli.date import date_now, DATE_METADATA_EDITION_FORMAT
 
 from .config import available_pipelines, boilerplate_questions
 
+confidentiality_map = {
+    "public": "green",
+    "restricted": "yellow",
+    "non-public": "red",
+}
+
 
 class DatasetsBoilerplateCommand(BaseCommand):
     __doc__ = f"""
@@ -105,8 +111,9 @@ Options:{BASE_COMMAND_OPTIONS}
             data["title"] = title
             data["description"] = config.get("description") or title
             data["objective"] = config.get("objective") or title
-            data["accessRights"] = config.get("accessRights")
-            data["confidentiality"] = config.get("confidentiality")
+            access_rights = config.get("accessRights")
+            data["accessRights"] = access_rights
+            data["confidentiality"] = confidentiality_map[access_rights]
             data["publisher"] = config.get("publisher")
             data["contactPoint"] = {
                 "name": config.get("name"),

--- a/origocli/commands/datasets/boilerplate/config.py
+++ b/origocli/commands/datasets/boilerplate/config.py
@@ -1,3 +1,5 @@
+from questionary import Choice
+
 from .validator import (
     DateValidator,
     EnvironmentValidator,
@@ -27,14 +29,12 @@ boilerplate_questions = [
     {
         "type": "select",
         "name": "accessRights",
-        "message": "Tilgang",
-        "choices": ["non-public", "public", "restricted"],
-    },
-    {
-        "type": "select",
-        "name": "confidentiality",
-        "message": "Nivå",
-        "choices": ["green", "yellow", "red", "purple"],
+        "message": "Tilgangsnivå",
+        "choices": [
+            Choice("Offentlig", "public"),
+            Choice("Begrenset offentlighet", "restricted"),
+            Choice("Unntatt offentlighet", "non-public"),
+        ],
     },
     {"type": "text", "name": "name", "message": "Kontaktperson - navn"},
     {


### PR DESCRIPTION
Unify the questions on dataset access rights and confidentiality in the boilerplate questionnaire. Also give the choices more explanatory labels.