### PR TITLE
DP-1310 Add dataset creation wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## ?.?.?
 
+* `origo datasets create` now runs a dataset creation wizard for setting up a
+  new dataset complete with a processing pipeline, ready to receive files. The
+  `--file` parameter can still be used when you want to create a dataset from a
+  configuration file.
+
 * The boilerplate command no longer prompts for an AWS account ID.
 
 * The questions on dataset access rights and confidentiality have been unified

--- a/doc/datasets.md
+++ b/doc/datasets.md
@@ -41,6 +41,16 @@ origo datasets ls --filter=<my-filter-string>
 
 ## Create dataset
 
+Enter `origo datasets create` to start the dataset creation wizard. After
+answering a number of questions, a new dataset is created along with a selected
+processing pipeline, ready to receive files.
+
+### From a configuration file
+
+Datasets can also be created from a configuration file if you need more fine
+grained control (this will not set up a pipeline). This method is also suitable
+if you need to script the dataset creation flow.
+
 File: `dataset.json`
 ```json
 {
@@ -59,13 +69,7 @@ File: `dataset.json`
 }
 ```
 
-Create the dataset by piping the contents of `dataset.json`:
-
-```bash
-cat dataset.json | origo datasets create
-```
-
-Or create it by referencing the file:
+Create the dataset by referencing the file:
 
 ```bash
 origo datasets create --file=dataset.json

--- a/origocli/commands/datasets/boilerplate/boilerplate.py
+++ b/origocli/commands/datasets/boilerplate/boilerplate.py
@@ -128,8 +128,6 @@ Options:{BASE_COMMAND_OPTIONS}
             data = json.load(json_file)
             data["edition"] = date_now().strftime(DATE_METADATA_EDITION_FORMAT)
             data["description"] = config.get("description") or title
-            data["startTime"] = config.get("startTime")
-            data["endTime"] = config.get("endTime")
         with open(edition_file, "w") as outfile:
             json.dump(data, outfile, indent=4)
 

--- a/origocli/commands/datasets/boilerplate/config.py
+++ b/origocli/commands/datasets/boilerplate/config.py
@@ -1,7 +1,6 @@
 from questionary import Choice
 
 from .validator import (
-    DateValidator,
     KeywordValidator,
     PhoneValidator,
     SimpleEmailValidator,

--- a/origocli/commands/datasets/boilerplate/config.py
+++ b/origocli/commands/datasets/boilerplate/config.py
@@ -49,16 +49,4 @@ boilerplate_questions = [
         "message": "Prosessering",
         "choices": available_pipelines,
     },
-    {
-        "type": "text",
-        "name": "startTime",
-        "message": "Start tidspunkt for datasett",
-        "validate": DateValidator,
-    },
-    {
-        "type": "text",
-        "name": "endTime",
-        "message": "Slutt tidspunkt for datasett",
-        "validate": DateValidator,
-    },
 ]

--- a/origocli/commands/datasets/datasets.py
+++ b/origocli/commands/datasets/datasets.py
@@ -1,17 +1,17 @@
+from origo.data.dataset import Dataset
+from origo.data.download import Download
+from origo.data.upload import Upload
+from origo.dataset_authorizer.simple_dataset_authorizer_client import (
+    SimpleDatasetAuthorizerClient,
+)
 from requests.exceptions import HTTPError
 
 from origocli.command import BaseCommand, BASE_COMMAND_OPTIONS
 from origocli.commands.datasets import DatasetsBoilerplateCommand
-from origocli.output import create_output
-from origocli.io import read_json, resolve_output_filepath
+from origocli.commands.datasets.wizards import DatasetCreateWizard
 from origocli.date import date_now, DATE_METADATA_EDITION_FORMAT
-
-from origo.data.dataset import Dataset
-from origo.data.upload import Upload
-from origo.data.download import Download
-from origo.dataset_authorizer.simple_dataset_authorizer_client import (
-    SimpleDatasetAuthorizerClient,
-)
+from origocli.io import read_json, resolve_output_filepath
+from origocli.output import create_output
 
 
 class DatasetsCommand(BaseCommand):
@@ -65,7 +65,10 @@ Options:{BASE_COMMAND_OPTIONS}
         elif self.arg("datasetid") is None and self.cmd("ls") is True:
             self.datasets()
         elif self.arg("datasetid") is None and self.cmd("create") is True:
-            self.create_dataset()
+            if self.opt("file"):
+                self.create_dataset()
+            else:
+                DatasetCreateWizard(self).start()
         elif self.cmd("cp") is True:
             self.copy_file()
         elif (

--- a/origocli/commands/datasets/wizards.py
+++ b/origocli/commands/datasets/wizards.py
@@ -62,7 +62,7 @@ class DatasetCreateWizard:
 
         self.command.print("Creating pipeline...")
         pipeline_client = PipelineApiClient(env=env)
-        pipeline_config = self.pipeline_config("data-copy", dataset_id, "1")
+        pipeline_config = self.pipeline_config(choices["pipeline"], dataset_id, "1")
         pipeline_id = pipeline_client.create_pipeline_instance(pipeline_config)
         pipeline_id = pipeline_id.strip('"')  # What's up with these?
         self.command.print(f"Created pipeline with ID: {pipeline_id}")

--- a/origocli/commands/datasets/wizards.py
+++ b/origocli/commands/datasets/wizards.py
@@ -1,0 +1,81 @@
+from origo.data.dataset import Dataset
+from origo.pipelines.client import PipelineApiClient
+from questionary import prompt
+
+from origocli.commands.datasets.boilerplate.boilerplate import confidentiality_map
+from origocli.commands.datasets.boilerplate.config import boilerplate_questions
+
+
+class DatasetCreateWizard:
+    """Wizard for the `datasets create` command.
+
+    Creates a new dataset, pipeline, and pipeline input based on the answers
+    from a questionnaire.
+    """
+
+    def __init__(self, command):
+        self.command = command
+
+    def dataset_config(self, choices):
+        title = choices["title"]
+        access_rights = choices["accessRights"]
+
+        return {
+            "title": title,
+            "description": choices["description"] or title,
+            "keywords": choices["keywords"].split(","),
+            "accessRights": access_rights,
+            "confidentiality": confidentiality_map[access_rights],
+            "objective": choices["objective"] or title,
+            "contactPoint": {
+                "name": choices["name"],
+                "email": choices["email"],
+                "phone": choices["phone"],
+            },
+            "publisher": choices["publisher"],
+        }
+
+    def pipeline_config(self, pipeline_processor_id, dataset_id, version):
+        return {
+            "pipelineProcessorId": pipeline_processor_id,
+            "id": dataset_id,
+            "datasetUri": f"output/{dataset_id}/{version}",
+        }
+
+    def pipeline_input_config(self, pipeline_id, dataset_id, version):
+        return {
+            "pipelineInstanceId": pipeline_id,
+            "datasetUri": f"input/{dataset_id}/{version}",
+            "stage": "raw",
+        }
+
+    def start(self):
+        env = self.command.opt("env")
+        choices = prompt(boilerplate_questions)
+
+        self.command.print("Creating dataset...")
+        dataset_client = Dataset(env=env)
+        dataset_config = self.dataset_config(choices)
+        dataset = dataset_client.create_dataset(dataset_config)
+        dataset_id = dataset["Id"]
+        self.command.print(f"Created dataset with ID: {dataset_id}")
+
+        self.command.print("Creating pipeline...")
+        pipeline_client = PipelineApiClient(env=env)
+        pipeline_config = self.pipeline_config("data-copy", dataset_id, "1")
+        pipeline_id = pipeline_client.create_pipeline_instance(pipeline_config)
+        pipeline_id = pipeline_id.strip('"')  # What's up with these?
+        self.command.print(f"Created pipeline with ID: {pipeline_id}")
+
+        self.command.print("Creating pipeline input...")
+        pipeline_input_config = self.pipeline_input_config(pipeline_id, dataset_id, "1")
+        pipeline_input_id = pipeline_client.create_pipeline_input(pipeline_input_config)
+        pipeline_input_id = pipeline_input_id.strip('"')  # What's up with these?
+        self.command.print(f"Created pipeline input with ID: {pipeline_input_id}")
+
+        self.command.print(
+            f"""Done! You may go ahead and upload data to the dataset by running:
+
+  origo datasets cp FILE ds:{dataset_id}
+"""
+        )

--- a/origocli/data/boilerplate/dataset/dataset-version-edition.json
+++ b/origocli/data/boilerplate/dataset/dataset-version-edition.json
@@ -1,6 +1,4 @@
 {
     "edition": "2020-00-00T08:00:00+02:00",
-    "description": "Boilerplate test",
-    "startTime": "2020-00-00",
-    "endTime": "2020-00-00"
+    "description": "Boilerplate test"
 }

--- a/tests/origocli/cli_test.py
+++ b/tests/origocli/cli_test.py
@@ -1,13 +1,14 @@
-import sys
 import json
-from requests.models import Response
+import sys
 
 import pytest
-from bin.cli import get_command_class, main
 from origo.exceptions import ApiAuthenticateError
 from origo.sdk import SDK
-from origocli.commands.datasets import DatasetsCommand
+from requests.models import Response
+
+from bin.cli import get_command_class, main
 from origocli.command import generate_error_feedback
+from origocli.commands.datasets import DatasetsCommand
 
 
 bad_request_response_body = {
@@ -17,13 +18,18 @@ bad_request_response_body = {
 
 
 def test_get_command_class():
-    argv = ["origo", "datasets"]
-    cmd = get_command_class(argv)
+    cmd = get_command_class(["origo", "datasets"])
+    assert cmd is DatasetsCommand
+
+    cmd = get_command_class(["origo", "datasets", "create"])
+    assert cmd is DatasetsCommand
+
+    cmd = get_command_class(["origo", "datasets", "create", "--file=foo"])
     assert cmd is DatasetsCommand
 
 
 def test_main_http_error(raise_http_error, capsys):
-    sys.argv = ["origo", "datasets", "create"]
+    sys.argv = ["origo", "datasets", "create", "--file=foo"]
     main()
     expected_output = generate_error_feedback(
         bad_request_response_body["message"], bad_request_response_body["errors"]


### PR DESCRIPTION
Make `origo datasets create` run a dataset creation wizard for setting up a new dataset complete with a processing pipeline, ready to receive files.

The `--file` parameter can still be used to create a dataset from a configuration file.