### PR TITLE
DP-1362 Simplify boilerplate pipeline configs

### DIFF
--- a/origocli/data/boilerplate/pipeline/csv-to-parquet/pipeline.json
+++ b/origocli/data/boilerplate/pipeline/csv-to-parquet/pipeline.json
@@ -1,8 +1,5 @@
 {
   "pipelineProcessorId": "csv-to-parquet",
-  "useLatestEdition": true,
   "id": "DATASET_ID",
-  "datasetUri": "output/DATASET_ID/DATASET_VERSION",
-  "schemaId": "",
-  "transformation": {}
+  "datasetUri": "output/DATASET_ID/DATASET_VERSION"
 }

--- a/origocli/data/boilerplate/pipeline/data-copy/pipeline.json
+++ b/origocli/data/boilerplate/pipeline/data-copy/pipeline.json
@@ -1,8 +1,5 @@
 {
   "pipelineProcessorId": "data-copy",
-  "useLatestEdition": true,
   "id": "DATASET_ID",
-  "datasetUri": "output/DATASET_ID/DATASET_VERSION",
-  "schemaId": "",
-  "transformation": {}
+  "datasetUri": "output/DATASET_ID/DATASET_VERSION"
 }


### PR DESCRIPTION
Simplify the pipeline configurations used by the boilerplate command by removing the obsolete fields `useLatestEdition`, `schemaId`, and `transformation`.