### PR TITLE
Remove `datasets download` from help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## ?.?.?
+
+* `origo datasets download` is no longer presented in the `origo datasets` help
+  text, since the command is gone. Use `origo datasets cp` instead.
+
 ## 0.6.0
 
 * `origo datasets create` now runs a dataset creation wizard for setting up a

--- a/origocli/commands/datasets/datasets.py
+++ b/origocli/commands/datasets/datasets.py
@@ -27,7 +27,6 @@ Usage:
   origo datasets create-distribution <datasetid> [<versionid> <editionid>] [--file=<file> --format=<format> --env=<env> options]
   origo datasets create-access <datasetid> <userid> [--format=<format> --env=<env> options]
   origo datasets check-access <datasetid> [--format=<format> --env=<env> options]
-  origo datasets download <datasetid> [<versionid> <editionid> <output_path>] [--format=<format> --env=<env> options]
   origo datasets boilerplate <name> [--file=<file> --prompt=<prompt> --pipeline=<pipeline> options]
 
 Examples:


### PR DESCRIPTION
The `datasets download` command was removed in commit 06093e7871e440882967afc7a596b690374aa304, but remained in the `datasets download` help text. Remove it.